### PR TITLE
Refactor sound logic in game

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ set(SOURCES main.cpp
         View/settings_menu.cpp
         View/settings_volume.cpp
         View/view.cpp
-        ${box2d})
+        ${box2d}
+        Model/sound.cpp
+        )
 
 qt5_add_big_resources(SOURCES resources.qrc)
 add_executable(jellyin ${SOURCES})

--- a/Controller/game_controller.h
+++ b/Controller/game_controller.h
@@ -86,8 +86,6 @@ class GameController : public AbstractGameController {
   std::shared_ptr<Player> player_ = nullptr;
 
   std::shared_ptr<AudioManager> audio_manager_;
-  int level_audio_key_;
-  int menu_audio_key_;
 
   int general_volume_ = 40;
   int music_volume_ = 40;

--- a/Model/audio_manager.cpp
+++ b/Model/audio_manager.cpp
@@ -1,122 +1,53 @@
 #include "audio_manager.h"
 
-AudioManager::AudioManager()
-    : audio_files_(static_cast<int>(AudioName::kAnyAudio)),
-      range_(1, 1000000),
-      random_generator_(std::mt19937(
-          std::chrono::system_clock::now().time_since_epoch().count())) {
-  audio_files_[static_cast<int>(AudioName::kButtonClick)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/menu/button_click.mp3"));
-  audio_files_[static_cast<int>(AudioName::kThorn)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/enemy/burdock_bullet.mp3"));
-  audio_files_[static_cast<int>(AudioName::kDrop)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/enemy/cloud_bullet.mp3"));
-  audio_files_[static_cast<int>(AudioName::kChestnut)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/enemy/chestnut.mp3"));
-  audio_files_[static_cast<int>(AudioName::kPlayerJump)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/player/jump.mp3"));
-  audio_files_[static_cast<int>(AudioName::kPlayerSeparation)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/player/separation.mp3"));
-  audio_files_[static_cast<int>(AudioName::kPlayerTakingDamage)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/player/taking_damage.mp3"));
-  audio_files_[static_cast<int>(AudioName::kPlayerGettingMushroom)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/player/mushroom.mp3"));
-  audio_files_[static_cast<int>(AudioName::kBackground)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/music/background.mp3"));
-  audio_files_[static_cast<int>(AudioName::kMenuAudio)] =
-      std::make_shared<QMediaContent>(
-          QUrl("qrc:/audio/music/menu.mp3"));
+AudioManager::AudioManager() {
+  audios_.resize(static_cast<int>(AudioName::kAnyAudio));
+  int key = static_cast<int>(AudioName::kButtonClick);
+  audios_[key] = std::make_shared<QMediaPlayer>();
+  audios_[key]->setAudioRole(QAudio::SonificationRole);
+  audios_[key]->setMedia(QUrl("qrc:/audio/menu/button_click.mp3"));
+  audios_[key]->setVolume(100);
+
+  key = static_cast<int>(AudioName::kMenuAudio);
+  audios_[key] = std::make_shared<QMediaPlayer>();
+  QMediaPlaylist* playlist1 = new QMediaPlaylist;
+  playlist1->addMedia(QUrl("qrc:/audio/music/menu.mp3"));
+  audios_[key]->setAudioRole(QAudio::MusicRole);
+  audios_[key]->setPlaylist(playlist1);
+  audios_[key]->setVolume(100);
+
+  key = static_cast<int>(AudioName::kBackground);
+  audios_[key] = std::make_shared<QMediaPlayer>();
+  QMediaPlaylist* playlist2 = new QMediaPlaylist;
+  playlist2->addMedia(QUrl("qrc:/audio/music/background.mp3"));
+  audios_[key]->setAudioRole(QAudio::MusicRole);
+  audios_[key]->setPlaylist(playlist2);
+  audios_[key]->setVolume(100);
 }
 
-int AudioManager::CreateAudioPlayer(AudioName audio_name) {
-  int key = range_(random_generator_);
-  audio_players_[key] = std::make_shared<QMediaPlayer>();
-  audio_players_[key]->setAudioRole(QAudio::GameRole);
-  audio_players_[key]->setMedia(*audio_files_[static_cast<int>(audio_name)]);
-  audio_players_[key]->setVolume(general_volume_ * current_volume_ / 100);
-
-  audio_players_[key]->play();
-  audio_players_[key]->stop();
-  return key;
+void AudioManager::Play(AudioName name) {
+  audios_[static_cast<int>(name)]->play();
 }
 
-int AudioManager::CreateAudioPlayerByPlayList(AudioName audio_name) {
-  int key = range_(random_generator_);
-  audio_players_[key] = std::make_shared<QMediaPlayer>();
-  QMediaPlaylist* playlist = new QMediaPlaylist;
-  playlist->addMedia(*audio_files_[static_cast<int>(audio_name)]);
-  audio_players_[key]->setAudioRole(QAudio::GameRole);
-  audio_players_[key]->setPlaylist(playlist);
-  audio_players_[key]->setVolume(general_volume_ * current_volume_ / 100);
-
-  audio_players_[key]->play();
-  audio_players_[key]->stop();
-  return key;
+void AudioManager::Replay(AudioName name) {
+  int key = static_cast<int>(name);
+  audios_[key]->setPosition(0);
+  audios_[key]->play();
 }
 
-void AudioManager::PlayAudioPlayer(int key) {
-  audio_players_[key]->play();
+void AudioManager::Stop(AudioName name) {
+  audios_[static_cast<int>(name)]->stop();
 }
 
-void AudioManager::ReplayAudioPlayer(int key) {
-  StopAudioPlayer(key);
-  PlayAudioPlayer(key);
+void AudioManager::Pause(AudioName name) {
+  audios_[static_cast<int>(name)]->pause();
 }
 
-void AudioManager::PauseAudioPlayer(int key) {
-  audio_players_[key]->pause();
+void AudioManager::SetVolume(AudioName name, int volume) {
+  audios_[static_cast<int>(name)]->setVolume(volume);
 }
 
-void AudioManager::StopAudioPlayer(int key) {
-  audio_players_[key]->stop();
-}
-
-void AudioManager::PlayAudio(AudioName audio_name, int volume) {
-  QMediaPlayer* audio_player = new QMediaPlayer;
-  audio_player->setMedia(*audio_files_[static_cast<int>(audio_name)]);
-  audio_player->setVolume(
-      volume * general_volume_ * current_volume_ / 10000);
-  audio_player->play();
-  QObject::connect(audio_player,
-                   &QMediaPlayer::mediaStatusChanged,
-                   [audio_player](QMediaPlayer::MediaStatus status) {
-                     if (status == QMediaPlayer::EndOfMedia) {
-                       audio_player->setMedia(nullptr);
-                       audio_player->deleteLater();
-                     }
-                   });
-}
-
-void AudioManager::SetVolume(int key, int volume) {
-  audio_players_[key]->setVolume(
-      volume * general_volume_ * current_volume_ / 10000);
-}
-
-void AudioManager::SetPlayBackMode(int key, QMediaPlaylist::PlaybackMode mode) {
-  audio_players_[key]->playlist()->setPlaybackMode(mode);
-}
-
-void AudioManager::ReVolume() {
-  for (auto& audio_player : audio_players_) {
-    audio_player.second->setVolume(general_volume_ * current_volume_ / 100);
-  }
-}
-
-void AudioManager::SetGeneralVolume(int volume) {
-  general_volume_ = volume;
-  ReVolume();
-}
-
-void AudioManager::SetCurrentVolume(int volume) {
-  current_volume_ = volume;
-  ReVolume();
+void AudioManager::SetPlayBackMode(AudioName name,
+                                   QMediaPlaylist::PlaybackMode mode) {
+  audios_[static_cast<int>(name)]->playlist()->setPlaybackMode(mode);
 }

--- a/Model/audio_manager.h
+++ b/Model/audio_manager.h
@@ -4,21 +4,11 @@
 #include <QMediaContent>
 #include <QMediaPlayer>
 #include <QMediaPlaylist>
-#include <algorithm>
 #include <memory>
-#include <random>
 #include <vector>
-#include <unordered_map>
 
 enum class AudioName {
   kButtonClick,
-  kThorn,
-  kDrop,
-  kChestnut,
-  kPlayerJump,
-  kPlayerSeparation,
-  kPlayerTakingDamage,
-  kPlayerGettingMushroom,
   kBackground,
   kMenuAudio,
   kAnyAudio
@@ -29,32 +19,16 @@ class AudioManager {
   AudioManager();
   ~AudioManager() = default;
 
-  void SetVolume(int key, int volume);
+  void Play(AudioName name);
+  void Replay(AudioName name);
+  void Pause(AudioName name);
+  void Stop(AudioName name);
+  void SetPlayBackMode(AudioName name, QMediaPlaylist::PlaybackMode mode);
 
-  int CreateAudioPlayer(AudioName audio_name);
-  int CreateAudioPlayerByPlayList(AudioName audio_name);
-  void PlayAudioPlayer(int key);
-  void ReplayAudioPlayer(int key);
-  void PauseAudioPlayer(int key);
-  void StopAudioPlayer(int key);
-  void PlayAudio(AudioName audio_name, int volume = 100);
-
-  void SetPlayBackMode(int key, QMediaPlaylist::PlaybackMode mode);
-
-  void ReVolume();
-
-  void SetCurrentVolume(int volume);
-  void SetGeneralVolume(int volume);
+  void SetVolume(AudioName name, int volume);
 
  private:
-  int general_volume_ = 100;
-  int current_volume_ = 100;
-
-  std::vector<std::shared_ptr<QMediaContent>> audio_files_;
-  std::unordered_map<int, std::shared_ptr<QMediaPlayer>> audio_players_;
-
-  std::mt19937 random_generator_;
-  std::uniform_int_distribution<> range_;
+  std::vector<std::shared_ptr<QMediaPlayer>> audios_;
 };
 
 #endif  // MODEL_AUDIO_MANAGER_H_

--- a/Model/entity.h
+++ b/Model/entity.h
@@ -10,6 +10,7 @@
 #include "audio_manager.h"
 #include "game_object.h"
 #include "map.h"
+#include "sound.h"
 
 class Entity : public GameObject {
  public:
@@ -93,6 +94,7 @@ class Entity : public GameObject {
 
   std::shared_ptr<Animator> animator_ = nullptr;
 
+  std::shared_ptr<Sound> chestnut_sound_;
  private:
   void InitializeBody(b2BodyType body_type, const QPoint& body_position);
 
@@ -110,8 +112,6 @@ class Entity : public GameObject {
   b2Vec2 target_velocity_ = {0, 0};
   bool is_active_ = true;
   EntityType entity_type_;
-  int player_get_mushroom_audio_key_;
-  int chestnut_audio_key_;
 };
 
 #endif  // MODEL_ENTITY_H_

--- a/Model/entity.h
+++ b/Model/entity.h
@@ -95,6 +95,7 @@ class Entity : public GameObject {
   std::shared_ptr<Animator> animator_ = nullptr;
 
   std::shared_ptr<Sound> chestnut_sound_;
+
  private:
   void InitializeBody(b2BodyType body_type, const QPoint& body_position);
 

--- a/Model/map.h
+++ b/Model/map.h
@@ -10,6 +10,7 @@
 #include "box2d/box2d.h"
 #include "camera.h"
 #include "game_object.h"
+#include "sound.h"
 
 // kAnyKey должен быть в enum последним
 enum class Key {
@@ -22,7 +23,8 @@ enum class Key {
 
 class Map {
  public:
-  explicit Map(const std::shared_ptr<QImage>& map_image);
+  Map(const std::shared_ptr<QImage>& map_image,
+      std::shared_ptr<std::vector<std::shared_ptr<Sound>>> sound_data);
   ~Map() = default;
 
   void Update(int time);
@@ -43,9 +45,7 @@ class Map {
 
   void PickUpMushroom();
 
-  std::shared_ptr<AudioManager> GetAudioManager() const;
-  void SetGeneralVolume(int general_volume);
-  void SetCurrentVolume(int current_volume);
+  void SetDefaultVolume(int volume);
 
   void UpdateCamera(QPainter* painter);
 
@@ -85,7 +85,9 @@ class Map {
   std::vector<bool> is_key_pressed_;
   std::vector<bool> is_key_clamped_;
 
-  std::shared_ptr<AudioManager> audio_manager_;
+  std::shared_ptr<Sound> mushroom_sound_;
+  // Sound data
+  std::shared_ptr<std::vector<std::shared_ptr<Sound>>> sound_data_;
 };
 
 #endif  // MODEL_MAP_H_

--- a/Model/patroller.cpp
+++ b/Model/patroller.cpp
@@ -15,3 +15,7 @@ Patroller::Patroller(std::weak_ptr<Map> map,
   animator_->Play();
   SetWayPoints(way_points);
 }
+
+void Patroller::InitializeSound(std::shared_ptr<Sound> patroller_sound) {
+  chestnut_sound_ = std::move(patroller_sound);
+}

--- a/Model/patroller.h
+++ b/Model/patroller.h
@@ -18,6 +18,8 @@ class Patroller : public Entity {
             std::shared_ptr<Animator> animator,
             int speed);
 
+  void InitializeSound(std::shared_ptr<Sound> patroller_sound);
+
   ~Patroller() override = default;
 };
 

--- a/Model/player.cpp
+++ b/Model/player.cpp
@@ -34,13 +34,14 @@ Player::Player(std::weak_ptr<Map> map,
   right_sensor_->SetSensor(true);
 
   SetNoCollisionMask(static_cast<uint16_t>(EntityType::kPlayer));
+}
 
-  player_jump_audio_key_ = map_.lock()->GetAudioManager()->
-      CreateAudioPlayer(AudioName::kPlayerJump);
-  player_separation_audio_key_ = map_.lock()->GetAudioManager()->
-      CreateAudioPlayer(AudioName::kPlayerSeparation);
-  player_receive_damage_audio_key_ = map_.lock()->GetAudioManager()->
-      CreateAudioPlayer(AudioName::kPlayerTakingDamage);
+void Player::InitializeSound(std::shared_ptr<Sound> jump_sound,
+                             std::shared_ptr<Sound> separation_sound,
+                             std::shared_ptr<Sound> receive_damage_sound) {
+  jump_sound_ = std::move(jump_sound);
+  separation_sound_ = std::move(separation_sound);
+  receive_damage_sound_ = std::move(receive_damage_sound);
 }
 
 void Player::Update(int time) {
@@ -71,8 +72,7 @@ void Player::Update(int time) {
     player_part_->SetAnimator(std::make_shared<Animator>(*animator_));
     map_.lock()->AddGameObject(player_part_);
 
-    map_.lock()->GetAudioManager()->
-        PlayAudioPlayer(player_separation_audio_key_);
+    separation_sound_->Play();
   }
 
   if (player_part_ != nullptr
@@ -88,7 +88,7 @@ void Player::Update(int time) {
     body_->ApplyLinearImpulseToCenter(
         b2Vec2(0, -kPlayerJumpSpeed * body_->GetMass()), true);
 
-    map_.lock()->GetAudioManager()->ReplayAudioPlayer(player_jump_audio_key_);
+    jump_sound_->Replay();
   }
   float target_speed = -body_->GetLinearVelocity().x;
   if (map_.lock()->IsKeyClamped(Key::kLeft) && left_collisions_ == 0) {
@@ -157,8 +157,7 @@ void Player::TakeDamage() {
   no_damage_time_left_ = kNoDamageTime;
   current_health_--;
 
-  map_.lock()->GetAudioManager()->
-      PlayAudioPlayer(player_receive_damage_audio_key_);
+  receive_damage_sound_->Play();
 }
 
 void Player::SetAnimationName(const QString& animation_name) {

--- a/Model/player.h
+++ b/Model/player.h
@@ -7,6 +7,7 @@
 #include "animator.h"
 #include "constants.h"
 #include "entity.h"
+#include "sound.h"
 
 class Player : public Entity {
  public:
@@ -28,6 +29,10 @@ class Player : public Entity {
 
   void SetAnimationName(const QString& animation_name);
   void SetCurrentLevel(int level_number);
+
+  void InitializeSound(std::shared_ptr<Sound> jump_sound,
+                      std::shared_ptr<Sound> separation_sound,
+                      std::shared_ptr<Sound> receive_damage_sound);
 
  public:
   static const int kPlayerWidth = 64;
@@ -65,9 +70,9 @@ class Player : public Entity {
 
   std::shared_ptr<Entity> player_part_ = nullptr;
 
-  int player_jump_audio_key_;
-  int player_separation_audio_key_;
-  int player_receive_damage_audio_key_;
+  std::shared_ptr<Sound> jump_sound_;
+  std::shared_ptr<Sound> separation_sound_;
+  std::shared_ptr<Sound> receive_damage_sound_;
 };
 
 #endif  // MODEL_PLAYER_H_

--- a/Model/shooter.h
+++ b/Model/shooter.h
@@ -31,14 +31,14 @@ class Shooter : public Entity {
           EntityType entity_type,
           int speed = 0);
 
+  void InitializeSound(std::shared_ptr<Sound> shooter_sound);
+
   ~Shooter() override = default;
 
   void Update(int time) override;
 
  private:
   std::shared_ptr<Entity> CreateBullet(const QPoint& bullet_position);
-
-  void InitializeAudio();
 
  private:
   BulletDirection bullet_direction_;
@@ -56,6 +56,8 @@ class Shooter : public Entity {
 
   std::shared_ptr<Animator> bullet_animator_;
 
+  std::shared_ptr<Sound> burdock_shoot_sound_;
+  std::shared_ptr<Sound> cloud_shoot_sound_;
   int thorn_audio_key_;
   std::vector<int> drop_audio_keys_;
 };

--- a/Model/sound.cpp
+++ b/Model/sound.cpp
@@ -1,0 +1,30 @@
+#include "sound.h"
+
+Sound::Sound(QUrl media) {
+  audio_ = std::make_shared<QMediaPlayer>();
+  audio_->setAudioRole(QAudio::GameRole);
+  audio_->setMedia(media);
+  default_volume_ = 100;
+  volume_ = 100;
+  audio_->setVolume(100);
+}
+
+void Sound::Play() {
+  audio_->play();
+}
+
+void Sound::Replay() {
+  audio_->setPosition(0);
+  audio_->play();
+}
+
+void Sound::SetVolume(int volume) {
+  volume_ = volume;
+  audio_->setVolume(default_volume_ * volume_ / 100);
+}
+
+void Sound::SetDefaultVolume(int volume) {
+  default_volume_ = volume;
+  audio_->setVolume(default_volume_ * volume_ / 100);
+}
+

--- a/Model/sound.h
+++ b/Model/sound.h
@@ -1,0 +1,23 @@
+#ifndef MODEL_SOUND_H_
+#define MODEL_SOUND_H_
+
+#include <QMediaContent>
+#include <QMediaPlayer>
+#include <memory>
+
+class Sound {
+ public:
+  Sound(QUrl media);
+
+  void Play();
+  void Replay();
+  void SetVolume(int volume);
+  void SetDefaultVolume(int volume);
+
+ private:
+  int volume_;
+  int default_volume_;
+  std::shared_ptr<QMediaPlayer> audio_;
+};
+
+#endif  // MODEL_SOUND_H_

--- a/Model/sound.h
+++ b/Model/sound.h
@@ -7,7 +7,7 @@
 
 class Sound {
  public:
-  Sound(QUrl media);
+  explicit Sound(QUrl media);
 
   void Play();
   void Replay();

--- a/View/choose_level_menu.cpp
+++ b/View/choose_level_menu.cpp
@@ -13,8 +13,9 @@ ChooseLevelMenu::ChooseLevelMenu(AbstractGameController* game_controller,
     game_controller_->OpenMainMenu();
   });
 
+  // Play sound
   connect(back_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
 
   std::vector<std::shared_ptr<ImageSet>>
@@ -40,8 +41,9 @@ ChooseLevelMenu::ChooseLevelMenu(AbstractGameController* game_controller,
       game_controller_->StartLevel(i);
     });
 
+    // Play sound
     connect(level_buttons_[i], &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
   }
 

--- a/View/intermediate_menu.cpp
+++ b/View/intermediate_menu.cpp
@@ -63,8 +63,10 @@ IntermediateMenu::IntermediateMenu(AbstractGameController* game_controller,
     connect(back_arrow_, &QPushButton::clicked, this, [&]() {
       game_controller_->OpenSettingsMenu();
     });
+
+    // Play sound
     connect(back_arrow_, &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
     return;
   }
@@ -85,14 +87,15 @@ IntermediateMenu::IntermediateMenu(AbstractGameController* game_controller,
     game_controller_->RestartGame();
   });
 
+  // Play sound
   connect(main_menu_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
   connect(choose_level_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
   connect(restart_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
 
   if (menu_type_ == MenuType::kPause) {
@@ -101,8 +104,9 @@ IntermediateMenu::IntermediateMenu(AbstractGameController* game_controller,
       game_controller_->ResumeGame();
     });
 
+    // Play sound
     connect(resume_button_, &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
   } else if (menu_type == MenuType::kVictory) {
     resume_button_ = new Button(image_set, this, "Next Level");
@@ -110,8 +114,9 @@ IntermediateMenu::IntermediateMenu(AbstractGameController* game_controller,
       game_controller_->StartNextLevel();
     });
 
+    // Play sound
     connect(resume_button_, &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
   }
 

--- a/View/main_menu.cpp
+++ b/View/main_menu.cpp
@@ -23,14 +23,15 @@ MainMenu::MainMenu(AbstractGameController* game_controller, QWidget* parent)
     qApp->exit();
   });
 
+  // Play sound
   connect(play_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
   connect(settings_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
   connect(exit_button_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
 }
 

--- a/View/menu.cpp
+++ b/View/menu.cpp
@@ -4,14 +4,6 @@ Menu::Menu(AbstractGameController* game_controller, QWidget* parent)
     : QWidget(parent), game_controller_(game_controller),
       audio_manager_(std::make_shared<AudioManager>()) {}
 
-void Menu::SetGeneralVolume(int general_volume) {
-  audio_manager_->SetGeneralVolume(general_volume);
-}
-
-void Menu::SetCurrentVolume(int current_volume) {
-  audio_manager_->SetCurrentVolume(current_volume);
-}
-
 void Menu::resizeEvent(QResizeEvent* event) {
   QWidget::resizeEvent(event);
 

--- a/View/menu.h
+++ b/View/menu.h
@@ -20,9 +20,6 @@ class Menu : public QWidget {
                 QWidget* parent = nullptr);
   ~Menu() override = default;
 
-  void SetGeneralVolume(int general_volume);
-  void SetCurrentVolume(int current_volume);
-
  protected:
   void resizeEvent(QResizeEvent*) override;
   void paintEvent(QPaintEvent*) override;

--- a/View/settings_menu.cpp
+++ b/View/settings_menu.cpp
@@ -19,29 +19,34 @@ SettingsMenu::SettingsMenu(AbstractGameController* game_controller,
   connect(back_arrow_, &QPushButton::clicked, this, [&]() {
     game_controller_->OpenMainMenu();
   });
-  connect(back_arrow_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
-  });
 
   connect(controls_, &QPushButton::clicked, this, [&]() {
     game_controller_->OpenSettingsControls();
-  });
-  connect(controls_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
   });
 
   connect(volume_, &QPushButton::clicked, this, [&]() {
     game_controller_->OpenSettingsVolume();
   });
-  connect(volume_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
-  });
 
   connect(reset_, &QPushButton::clicked, this, [&]() {
     game_controller_->Reset();
   });
+
+  // Play sound
+  connect(back_arrow_, &QPushButton::pressed, this, [&]() {
+    audio_manager_->Replay(AudioName::kButtonClick);
+  });
+
+  connect(controls_, &QPushButton::pressed, this, [&]() {
+    audio_manager_->Replay(AudioName::kButtonClick);
+  });
+
+  connect(volume_, &QPushButton::pressed, this, [&]() {
+    audio_manager_->Replay(AudioName::kButtonClick);
+  });
+
   connect(reset_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
 }
 

--- a/View/settings_volume.cpp
+++ b/View/settings_volume.cpp
@@ -28,8 +28,10 @@ SettingsVolume::SettingsVolume(AbstractGameController* game_controller,
   connect(back_arrow_, &QPushButton::clicked, this, [&]() {
     game_controller_->OpenSettingsMenu();
   });
+
+  // Play sound
   connect(back_arrow_, &QPushButton::pressed, this, [&]() {
-    audio_manager_->PlayAudio(AudioName::kButtonClick);
+    audio_manager_->Replay(AudioName::kButtonClick);
   });
 
   for (int i = 0; i < 3; i++) {
@@ -43,8 +45,10 @@ SettingsVolume::SettingsVolume(AbstractGameController* game_controller,
       squares_[i]->SetText(QString::number(power));
       game_controller_->SetVolume(volume, power);
     });
+
+    // Play sound
     connect(right_arrows_[i], &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
 
     connect(left_arrows_[i], &QPushButton::clicked, this, [&, i]() {
@@ -57,8 +61,10 @@ SettingsVolume::SettingsVolume(AbstractGameController* game_controller,
       squares_[i]->SetText(QString::number(power));
       game_controller_->SetVolume(volume, power);
     });
+
+    // Play sound
     connect(left_arrows_[i], &QPushButton::pressed, this, [&]() {
-      audio_manager_->PlayAudio(AudioName::kButtonClick);
+      audio_manager_->Replay(AudioName::kButtonClick);
     });
   }
 }

--- a/jellyin.pro
+++ b/jellyin.pro
@@ -84,8 +84,7 @@ SOURCES += \
         box2d/dynamics/b2_world.cpp \
         box2d/dynamics/b2_world_callbacks.cpp \
         box2d/rope/b2_rope.cpp \
-        Model/sound.cpp \
-        Model/mushroom.cpp
+        Model/sound.cpp
 
 HEADERS += \
     Controller/abstract_game_controller.h \
@@ -163,8 +162,7 @@ HEADERS += \
     box2d/dynamics/b2_island.h \
     box2d/dynamics/b2_polygon_circle_contact.h \
     box2d/dynamics/b2_polygon_contact.h \
-    Model/sound.h \
-    Model/mushroom.h
+    Model/sound.h
 
 RESOURCES += \
     resources.qrc

--- a/jellyin.pro
+++ b/jellyin.pro
@@ -83,7 +83,9 @@ SOURCES += \
         box2d/dynamics/b2_wheel_joint.cpp \
         box2d/dynamics/b2_world.cpp \
         box2d/dynamics/b2_world_callbacks.cpp \
-        box2d/rope/b2_rope.cpp
+        box2d/rope/b2_rope.cpp \
+        Model/sound.cpp \
+        Model/mushroom.cpp
 
 HEADERS += \
     Controller/abstract_game_controller.h \
@@ -160,7 +162,9 @@ HEADERS += \
     box2d/dynamics/b2_edge_polygon_contact.h \
     box2d/dynamics/b2_island.h \
     box2d/dynamics/b2_polygon_circle_contact.h \
-    box2d/dynamics/b2_polygon_contact.h
+    box2d/dynamics/b2_polygon_contact.h \
+    Model/sound.h \
+    Model/mushroom.h
 
 RESOURCES += \
     resources.qrc


### PR DESCRIPTION
Аудио разделено на два больших типа: то что используется в меню,
хранится в одном месте (AudioManager), и звуки во время самого прохождения
(хранятся непосредственно в каждом объекте отдельно), для более комфортного
доступа к ним их копии хранятся в векторе в классе map. Это способствовало
исчезновению еще одного метода, для которого нужен был weak_ptr.